### PR TITLE
update webpack-cli to 4.5.0 (as in mapstore2 repo)

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
         "vusion-webfonts-generator": "0.4.1",
         "webpack": "5.9.0",
         "webpack-bundle-size-analyzer": "2.0.2",
-        "webpack-cli": "4.2.0",
+        "webpack-cli": "4.5.0",
         "webpack-dev-server": "3.11.0",
         "zip-webpack-plugin": "^3.0.0"
     },


### PR DESCRIPTION
 fixes issue : #7 

without that, on a fresh install, npm start fails with error on serve 
![mapstore-ext-webpack-cli-outdated](https://user-images.githubusercontent.com/78360657/112649184-7bc27e00-8e4a-11eb-9693-a65f40d7990a.png)
