### PR TITLE
#4 Removed tools from Map plugin config

### DIFF
--- a/localConfig.json
+++ b/localConfig.json
@@ -182,8 +182,7 @@
                           "altShiftDragRotate": false
                         }
                       }
-                    },
-                    "tools": ["locate"]
+                    }
                 }
             }, "Version", "DrawerMenu",
             {
@@ -481,7 +480,6 @@
         "embedded": ["Details", {
                 "name": "Map",
                 "cfg": {
-                    "tools": ["locate"],
                     "mapOptions": {
                     "openlayers": {
                       "interactions": {


### PR DESCRIPTION
This fixes the issue reported in #4, caused by a missed migration of configurations for mobile.

See https://mapstore.readthedocs.io/en/latest/developer-guide/mapstore-migration-guide/#locate-plugin-configuration