### PR TITLE
[fix] Error: Unknown option '--env.production'

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "scripts": {
         "postinstall": "node MapStore2/utility/build/postInstall.js",
         "clean": "rimraf dist",
-        "compile": "npm run clean && mkdirp ./dist && node --max_old_space_size=2048 ./node_modules/webpack/bin/webpack.js --config prod-webpack.config.js --env.production",
+        "compile": "npm run clean && mkdirp ./dist && node --max_old_space_size=2048 ./node_modules/webpack/bin/webpack.js --config prod-webpack.config.js --env production",
         "start": "webpack serve --progress --color --port 8081 --hot --inline --content-base .",
         "ext:startapp": "webpack serve --progress --color --port 8081 --hot --inline --content-base . --config build/extension/module.app.webpack.config.js",
         "ext:start": "webpack serve --progress --color --port 8082 --hot --inline --config build/extension/webpack.config.js",


### PR DESCRIPTION
The webpack-cli was recently updated, but comes with a new arguments parser. 

When running npm run compile (same commando used in ./build.sh) this gave the error:
```
Error: Unknown option '--env.production'
```

I updated the command according to webpack issue: https://github.com/webpack/webpack-cli/issues/1216