### PR TITLE
Provide Buffer plugin

### DIFF
--- a/build/extension/prod-webpack.config.js
+++ b/build/extension/prod-webpack.config.js
@@ -3,6 +3,7 @@ const path = require("path");
 
 const createExtensionWebpackConfig = require('../../MapStore2/build/createExtensionWebpackConfig');
 const CopyPlugin = require('copy-webpack-plugin');
+const ProvidePlugin = require("webpack/lib/ProvidePlugin");
 const ZipPlugin = require('zip-webpack-plugin');
 const {name} = require('../../config');
 const commons = require('./commons');
@@ -13,6 +14,9 @@ const plugins = [
         { from: path.resolve(__dirname, "..", "..", "assets", "translations"), to: "translations" },
         { from: path.resolve(__dirname, "..", "..", "assets", "index.json"), to: "index.json" }
     ]),
+    new ProvidePlugin({
+        Buffer: ['buffer', 'Buffer']
+    }),
     new ZipPlugin({
         filename: `${name}.zip`,
         pathMapper: assetPath => {


### PR DESCRIPTION
Provide Buffer plugin in webpack to use it in extension instead of having the following issue "Buffer is not defined".

Exemple : Using the library "shpjs" in an extension trigger the error. The submobule Mapstore2 provides the Buffer in his webpack. To use it in extensions, we need to provide it in the Extension project.