### PR TITLE
fix #20 with commented missing line

### DIFF
--- a/js/app.jsx
+++ b/js/app.jsx
@@ -13,6 +13,10 @@ const ConfigUtils = require('@mapstore/utils/ConfigUtils').default;
  * Add custom (overriding) translations with:
  *
  * ConfigUtils.setConfigProp('translationsPath', ['./MapStore2/web/client/translations', './translations']);
+ *
+ * Add this line to use /config.json root file :
+ *
+ * ConfigUtils.setConfigProp("configurationFolder", "");
  */
 ConfigUtils.setConfigProp('translationsPath', './MapStore2/web/client/translations');
 ConfigUtils.setConfigProp('themePrefix', 'MapStoreExtension');


### PR DESCRIPTION
#20

Comment missing line to open a default /config.json file from localhost:8081 directly (with single page custom config - e.g issue above)