### PR TITLE
Add @mapstore/patcher alias to build the extension

### DIFF
--- a/build/extension/commons.js
+++ b/build/extension/commons.js
@@ -10,6 +10,7 @@ module.exports = {
     destination: path.join(__dirname, '..', '..', "dist"),
     // to compile properly also mapstore dependencies
     alias: {
+        "@mapstore/patcher": path.resolve(__dirname, '..', '..', "node_modules", "@mapstore", "patcher"),
         "@mapstore": path.resolve(__dirname, '..', '..', "MapStore2", "web", "client"),
         "@js": path.resolve(__dirname, '..', '..', "js")
     }


### PR DESCRIPTION
if the @mapstore/patcher alias is missing the extension build will fail. This PR adds the correct alias to the common.js config