### PR TITLE
#28 - align localConfig path with 2022.x configs folder

### DIFF
--- a/js/app.jsx
+++ b/js/app.jsx
@@ -19,7 +19,7 @@ ConfigUtils.setConfigProp('themePrefix', 'MapStoreExtension');
 /**
  * Use a custom plugins configuration file with:
  *
- * ConfigUtils.setLocalConfigurationFile('localConfig.json');
+ * ConfigUtils.setLocalConfigurationFile('configs/localConfig.json');
  *
  * Use a custom application configuration file with:
  *


### PR DESCRIPTION
Link https://github.com/geosolutions-it/MapStoreExtension/issues/28

Avoid first error with wrong localConfig path when use use v 2022.x