### PR TITLE
#46 fix backend build on stable branch 2022.02.xx 

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -23,7 +23,7 @@ jobs:
       - name: "checking out"
         uses: actions/checkout@v2
       - name: "Checkout submodules"
-        run: git submodule update --init --recursive    
+        run: git submodule update --init --recursive
 
       - name: "setting up npm"
         uses: actions/setup-node@v2
@@ -44,7 +44,10 @@ jobs:
 
       - name: build
         run: npm run ext:build
-      
+
+      - name: build-backend
+        run: npm run be:build
+
       - name: 'Upload Artifact'
         uses: actions/upload-artifact@v2
         with:

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -2,8 +2,8 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>it.geosolutions.mapstore</groupId>
-    <artifactId>mapstore-root</artifactId>
+    <groupId>it.geosolutions.MapStoreExtension</groupId>
+    <artifactId>MapStoreExtension-root</artifactId>
     <version>1.0-SNAPSHOT</version>
   </parent>
   <artifactId>mapstore-web</artifactId>


### PR DESCRIPTION
fixing error #46 on stable branch 2022.02.xx 

```
$ npm run be:build

> MapStoreExtension@1.0.0 be:build C:\Work\projects\AAA_Geosolutions\MapStoreExtension
> mvn clean install

[INFO] Scanning for projects...
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[WARNING] 'parent.relativePath' of POM it.geosolutions.mapstore:mapstore-web:1.0-SNAPSHOT (C:\Work\projects\AAA_Geosolutions\MapStoreExtension\web\pom.xml) points at it.geosolutions.MapStoreExtension:MapStoreExtension-root instead of it.geosolutions.mapstore:mapstore-root, please verify your project structure @ line 4, column 11
[FATAL] Non-resolvable parent POM for it.geosolutions.mapstore:mapstore-web:1.0-SNAPSHOT: Failure to find it.geosolutions.mapstore:mapstore-root:pom:1.0-SNAPSHOT in https://maven.geo-solutions.it was cached in the local repository, resolution will not be reattempted until the update interval of geosolutions has elapsed or updates are forced and 'parent.relativePath' points at wrong local POM @ line 4, column 11
 @
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]
[ERROR]   The project it.geosolutions.mapstore:mapstore-web:1.0-SNAPSHOT (C:\Work\projects\AAA_Geosolutions\MapStoreExtension\web\pom.xml) has 1 error[ERROR]     Non-resolvable parent POM for it.geosolutions.mapstore:mapstore-web:1.0-SNAPSHOT: Failure to find it.geosolutions.mapstore:mapstore-root:pom:1.0-SNAPSHOT in https://maven.geo-solutions.it was cached in the local repository, resolution will not be reattempted until the update interval of 
geosolutions has elapsed or updates are forced and 'parent.relativePath' points at wrong local POM @ line 4, column 11 -> [Help 2]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException
[ERROR] [Help 2] http://cwiki.apache.org/confluence/display/MAVEN/UnresolvableModelException
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! MapStoreExtension@1.0.0 be:build: `mvn clean install`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the MapStoreExtension@1.0.0 be:build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
```

adding also a check for Be build