### PR TITLE
Update github actions to node 20

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -30,7 +30,7 @@ jobs:
       - name: "setting up npm"
         uses: actions/setup-node@v2
         with:
-            node-version: '16.x'
+            node-version: '20.x'
 
       ###############
       # NPM CHECKS


### PR DESCRIPTION
This PR updates the actions to node 20, after https://github.com/geosolutions-it/MapStore2/pull/10559 makes this node 20 compatible, to test with recommanded version.