### PR TITLE
Add issues/11256 behavior to track the version of extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ web/.classpath
 web/.project
 backend/.classpath
 backend/.project
+assets/index.json.tmp

--- a/assets/index.json
+++ b/assets/index.json
@@ -2,6 +2,7 @@
   "plugins": [
     {
       "name": "SampleExtension",
+      "version": "@@VERSION@@",
       "dependencies": [
         "Toolbar"
       ]

--- a/build/extension/prod-webpack.config.js
+++ b/build/extension/prod-webpack.config.js
@@ -9,13 +9,11 @@ const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const {name} = require('../../config');
 const commons = require('./commons');
 
-// read version.txt and produce a temporary updated index.json
-const versionFile = path.resolve(__dirname, "..", "..", "version.txt");
+// read version and produce a temporary updated index.json
+const { version: versionText } = require('../../package.json');
 const indexSrc = path.resolve(__dirname, "..", "..", "assets", "index.json");
 const tmpIndex = path.resolve(__dirname, "..", "..", "assets", "index.json.tmp");
-
 try {
-    const versionText = fs.readFileSync(versionFile, 'utf8').trim().split('-')[1];
     const indexContent = JSON.parse(fs.readFileSync(indexSrc, 'utf8'));
     if (Array.isArray(indexContent.plugins)) {
         indexContent.plugins = indexContent.plugins.map(p => p && p.name === name ? { ...p, version: versionText } : p);
@@ -26,12 +24,11 @@ try {
     console.error('Error updating index.json from version.txt:', e);
 }
 
-
 // the build configuration for production allow to create the final zip file, compressed accordingly
 const plugins = [
     new CopyPlugin([
         { from: path.resolve(__dirname, "..", "..", "assets", "translations"), to: "translations" },
-        { from: tmpIndex, to: 'index.json' },
+        { from: tmpIndex, to: 'index.json' }
     ]),
     new ZipPlugin({
         filename: `${name}.zip`,

--- a/build/extension/prod-webpack.config.js
+++ b/build/extension/prod-webpack.config.js
@@ -1,17 +1,37 @@
 
 const path = require("path");
+const fs = require("fs");
 
 const createExtensionWebpackConfig = require('../../MapStore2/build/createExtensionWebpackConfig');
 const CopyPlugin = require('copy-webpack-plugin');
 const ZipPlugin = require('zip-webpack-plugin');
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const {name} = require('../../config');
 const commons = require('./commons');
+
+// read version.txt and produce a temporary updated index.json
+const versionFile = path.resolve(__dirname, "..", "..", "version.txt");
+const indexSrc = path.resolve(__dirname, "..", "..", "assets", "index.json");
+const tmpIndex = path.resolve(__dirname, "..", "..", "assets", "index.json.tmp");
+
+try {
+    const versionText = fs.readFileSync(versionFile, 'utf8').trim().split('-')[1];
+    const indexContent = JSON.parse(fs.readFileSync(indexSrc, 'utf8'));
+    if (Array.isArray(indexContent.plugins)) {
+        indexContent.plugins = indexContent.plugins.map(p => p && p.name === name ? { ...p, version: versionText } : p);
+    }
+    fs.writeFileSync(tmpIndex, JSON.stringify(indexContent, null, 4), 'utf8');
+} catch (e) {
+    // keep behavior silent here; build will fail later if necessary
+    console.error('Error updating index.json from version.txt:', e);
+}
+
 
 // the build configuration for production allow to create the final zip file, compressed accordingly
 const plugins = [
     new CopyPlugin([
         { from: path.resolve(__dirname, "..", "..", "assets", "translations"), to: "translations" },
-        { from: path.resolve(__dirname, "..", "..", "assets", "index.json"), to: "index.json" }
+        { from: tmpIndex, to: 'index.json' },
     ]),
     new ZipPlugin({
         filename: `${name}.zip`,
@@ -22,6 +42,10 @@ const plugins = [
             // other files have to be placed in the root, with the same name
             return path.basename(assetPath);
         }
+    }),
+    new CleanWebpackPlugin({
+        cleanOnceBeforeBuildPatterns: [],
+        cleanAfterEveryBuildPatterns: [tmpIndex]
     })
 ];
 module.exports = createExtensionWebpackConfig({ prod: true, name, ...commons, plugins});

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
         "babel-plugin-object-assign": "1.2.1",
         "babel-plugin-react-transform": "2.0.2",
         "babel-plugin-transform-imports": "2.0.0",
+        "clean-webpack-plugin": "^4.0.0",
         "copy-webpack-plugin": "5.0.2",
         "css-loader": "5.1.2",
         "css-minimizer-webpack-plugin": "3.0.2",


### PR DESCRIPTION
In coherence with the https://github.com/geosolutions-it/MapStore2/issues/11256 issue which provide a way to display version of a deploy plugin in contexte creation, the proposal :

- add version field in index.json
- populate this field with the value in version.txt file
- build the zip with the provided value

Fix  https://github.com/geosolutions-it/MapStore2/issues/11256